### PR TITLE
Gigモデルの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,13 +64,13 @@ h2 {
   position: relative;
   overflow: auto;
   .wrapper {
-    display: flex;
+    // display: flex;
     flex-direction: column;
     .main {
       width: 100%;
       margin: 50px auto;
       &__contents {
-        display: flex;
+        // display: flex;
         flex-wrap: flex;
         font-size: 16px;
         &__content {
@@ -84,18 +84,24 @@ h2 {
           &--date {
             margin-bottom: 5px;
           }
+          &--location {
+            margin-bottom: 5px;
+          }
           &--genre {
             margin-bottom: 5px;
           }
-          &--need {
-            display: flex;
-            justify-content: center;
-            height: 40px;
-            line-height: 40px;
+          &--user {
             margin-bottom: 5px;
+          }
+          &--need {
+            // display: flex;
+            height: auto;
+            // line-height: 40px;
+            word-break: keep-all;
             align-items: center;
             margin: 0 auto;
             &--part {
+              margin-bottom: 10px;
               margin-right: 20px;
             }
           }

--- a/app/assets/stylesheets/gigs.scss
+++ b/app/assets/stylesheets/gigs.scss
@@ -6,57 +6,65 @@
   padding-top: 75px;
   height: 100vh;
   overflow: auto;
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    .main {
-      width: 100%;
-      margin: 50px auto;
-      &__contents {
-        display: flex;
-        flex-wrap: flex;
-        font-size: 16px;
-        &__content {
-          height: 100%;
-          padding: 10px;
-          text-align: center;
-          margin-bottom: 40px;
-          &--name {
-            margin-bottom: 5px;
-          }
-          &--date {
-            margin-bottom: 5px;
-          }
-          &--location {
-            margin-bottom: 5px;
-          }
-          &--genre {
-            margin-bottom: 5px;
-          }
-          &--user a {
-            margin-bottom: 10px;
-          }
-          &--need {
-            display: flex;
-            justify-content: center;
-            height: 40px;
-            line-height: 40px;
-            margin-top: 10px;
-            text-align: center;
-            align-items: center;
-            margin: 0 auto;
-            &--part {
-              margin-right: 20px;
-            }
-          }
-        }
-      }
-    }
+  // .wrapper {
+  //   // display: flex;
+  //   flex-direction: column;
+  //   .main {
+  //     width: 100%;
+  //     margin: 50px auto;
+  //     &__contents {
+  //       // display: flex;
+  //       flex-wrap: flex;
+  //       font-size: 16px;
+  //       &__content {
+  //         height: 100%;
+  //         padding: 10px;
+  //         text-align: center;
+  //         &--name {
+  //           margin-bottom: 5px;
+  //         }
+  //         &--date {
+  //           margin-bottom: 5px;
+  //         }
+  //         &--location {
+  //           margin-bottom: 5px;
+  //         }
+  //         &--genre {
+  //           margin-bottom: 5px;
+  //         }
+  //         &--user a {
+  //           margin-bottom: 5px;
+  //         }
+  //         &--need {
+  //           // display: flex;
+  //           // justify-content: center;
+  //           // height: 40px;
+  //           // line-height: 40px;
+  //           margin-top: 10px;
+  //           text-align: center;
+  //           // align-items: center;
+  //           // margin: 0 auto;
+  //           &--part {
+  //             margin-right: 20px;
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
     .container__gig {
       display: flex;
       &__left{
+        &__parts {
+          width: 400px;
+          word-break: keep-all;
+          text-indent: -6.2em;
+          padding-left: 6.2em;
+        }
+        .btn-warning {
+          margin-bottom: 20px;
+        }
         .btn-primary {
-          margin-left: 10px;
+          margin-bottom: 20px;
         }
         .btn-danger {
           font-family: 'Gotmilk';
@@ -86,7 +94,7 @@
         padding-bottom: 80px;
       }
     }    
-  }
+  // }
 }
 
 .entry {
@@ -103,4 +111,8 @@
       line-height: 24px;
     }
   }
+}
+
+.part-ids {
+  font-size: 40px;
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -35,9 +35,13 @@
       }
       .field {
         margin-bottom: 20px;
+        &__part {
+          margin-right: 15px;
+        }
       }
       .actions {
         margin-bottom: 20px;
       }
   }
 }
+

--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -3,12 +3,12 @@ class GigsController < ApplicationController
   before_action :set_gig, only: [:show, :destroy]
 
   def index
-    @gigs = Gig.limit(30).includes(:parts, :user).order('created_at DESC')
+    @gigs = Gig.limit(30).includes(:user).order('created_at DESC')
   end
 
   def new
     @gig = Gig.new
-    @gig.parts.build
+    # @gig.parts.build
   end
 
   def create
@@ -16,8 +16,7 @@ class GigsController < ApplicationController
     url = params[:gig][:youtube]
     url = url.last(11)
     @gig.youtube = url
-    if @gig.parts.present?
-      @gig.save
+    if @gig.save
       redirect_to root_path
       flash[:notice] = "gigが投稿されました"
     else
@@ -41,7 +40,7 @@ class GigsController < ApplicationController
 
   private
     def gig_params
-      params.require(:gig).permit(:name, :datetime, :location, :genre, :youtube, parts_attributes: [:name]).merge(user_id: current_user.id)
+      params.require(:gig).permit(:name, :datetime, :location, :genre, :youtube, parts: []).merge(user_id: current_user.id)
     end
 
     def set_gig

--- a/app/models/gig.rb
+++ b/app/models/gig.rb
@@ -1,7 +1,15 @@
 class Gig < ApplicationRecord
   belongs_to :user
-  has_many :parts, dependent: :destroy
+  has_many :gig_parts
+  # has_many :parts, through: :gig_parts
   has_many :entries, dependent: :destroy
+  before_save :parts_array
 
-  accepts_nested_attributes_for :parts
+  def parts_array
+    self.parts.gsub!(/[\[\]\"]/, "").gsub!(" ","") if attribute_present?("parts")
+  end
+
+  # before_save do
+  #   self.parts.split(',').map{|m| m.delete('[]"\\\\')} if attribute_present?("parts")
+  # end
 end

--- a/app/models/gig_part.rb
+++ b/app/models/gig_part.rb
@@ -1,0 +1,4 @@
+class GigPart < ApplicationRecord
+  belongs_to :part
+  belongs_to :gig
+end

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -1,5 +1,7 @@
 class Part < ApplicationRecord
-  belongs_to :gig
-
+  has_many :gig_parts
+  # has_many :gigs, through: :gig_parts
   validates :name, presence: true
+
+  accepts_nested_attributes_for :gig_parts
 end

--- a/app/views/gigs/index.html.haml
+++ b/app/views/gigs/index.html.haml
@@ -16,8 +16,13 @@
               投稿者：#{gig.user.name}
             .main__contents__content--need
               .main__contents__content--need--part
-                = gig.parts.first.name
-                - if gig.user == current_user
-                  = link_to "エントリー状況", gig_entries_path(gig), class: "btn btn-warning"
-                - else
-                  = link_to "エントリーへ", gig_entries_path(gig), class: "btn btn-primary"
+                募集パート：
+                - if gig.parts.present?
+                  - gig_parts = gig.parts
+                  - array_parts = gig_parts.split(",")
+                  - array_parts.each do |array_part|
+                    = array_part
+            - if gig.user == current_user
+              = link_to "エントリー状況", gig_entries_path(gig), class: "btn btn-warning"
+            - else
+              = link_to "エントリーへ", gig_entries_path(gig), class: "btn btn-primary"

--- a/app/views/gigs/new.html.haml
+++ b/app/views/gigs/new.html.haml
@@ -19,11 +19,35 @@
         = f.label :ジャンル
         %br/
         = f.text_field :genre
-      = f.fields_for :parts do |i|
-        .field
-          = f.label :募集パート
-          %br/
-          = i.text_field :name
+      .field
+        = f.label :募集パート
+        %br/
+        %label
+          ボーカル
+          %input{type: "checkbox", name: "gig[parts][]", value: "ボーカル", class: "field__part"}
+        %label
+          ギター
+          %input{type: "checkbox", name: "gig[parts][]", value: "ギター", class: "field__part"}
+        %label
+          キーボード
+          %input{type: "checkbox", name: "gig[parts][]", value: "キーボード", class: "field__part"}
+        %label
+          ピアノ
+          %input{type: "checkbox", name: "gig[parts][]", value: "ピアノ", class: "field__part"}
+        %label
+          ベース
+          %input{type: "checkbox", name: "gig[parts][]", value: "ベース", class: "field__part"}
+        %label
+          ドラム
+          %input{type: "checkbox", name: "gig[parts][]", value: "ドラム", class: "field__part"}
+        %label
+          その他
+          %input{type: "text_field", name: "gig[parts][]"}
+      -# = f.fields_for :parts do |i|
+      -#   .field
+      -#     = f.label :募集パート
+      -#     %br/
+      -#     = i.text_field :name
       .field
         = f.label :YouTube, "参考動画（YouTube）"
         %br/

--- a/app/views/gigs/show.html.haml
+++ b/app/views/gigs/show.html.haml
@@ -18,13 +18,17 @@
         .field
           投稿者：
           = @gig.user.name
-        .field
+        .field.container__gig__left__parts
           募集パート：
-          = @gig.parts.first.name
-          - if @gig.user == current_user
-            = link_to "エントリー状況", gig_entries_path(@gig), class: "btn btn-warning"
-          - else
-            = link_to "エントリーへ", gig_entries_path(@gig), class: "btn btn-primary"
+          - if @gig.parts.present?
+            - gig_parts = @gig.parts
+            - array_parts = gig_parts.split(",")
+            - array_parts.each do |array_part|
+              = array_part
+        - if @gig.user == current_user
+          = link_to "エントリー状況", gig_entries_path(@gig), class: "btn btn-warning"
+        - else
+          = link_to "エントリーへ", gig_entries_path(@gig), class: "btn btn-primary"
         %br/
         - if @gig.user_id == current_user.id
           = link_to "gig 削除", gig_path(@gig), method: :delete, class: "btn btn-danger"

--- a/db/migrate/20191118040258_create_gig_parts.rb
+++ b/db/migrate/20191118040258_create_gig_parts.rb
@@ -1,0 +1,10 @@
+class CreateGigParts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :gig_parts do |t|
+      t.references :part, index: true, foreign_key: true
+      t.references :gig, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191118082037_add_parts_to_gigs.rb
+++ b/db/migrate/20191118082037_add_parts_to_gigs.rb
@@ -1,0 +1,5 @@
+class AddPartsToGigs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gigs, :parts, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_083828) do
+ActiveRecord::Schema.define(version: 2019_11_18_082037) do
 
   create_table "entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "content"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2019_11_14_083828) do
     t.index ["user_id"], name: "index_entries_on_user_id"
   end
 
+  create_table "gig_parts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "part_id"
+    t.bigint "gig_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["gig_id"], name: "index_gig_parts_on_gig_id"
+    t.index ["part_id"], name: "index_gig_parts_on_part_id"
+  end
+
   create_table "gigs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "datetime"
@@ -31,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_083828) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "youtube"
+    t.text "parts"
     t.index ["user_id"], name: "index_gigs_on_user_id"
   end
 
@@ -85,6 +95,8 @@ ActiveRecord::Schema.define(version: 2019_11_14_083828) do
 
   add_foreign_key "entries", "gigs"
   add_foreign_key "entries", "users"
+  add_foreign_key "gig_parts", "gigs"
+  add_foreign_key "gig_parts", "parts"
   add_foreign_key "gigs", "users"
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"


### PR DESCRIPTION
# What
最初はPartモデルを作成し、Gigモデルにアソシエーションで繋がる設計をしていたが、Partモデルの必要性がなく、Gigモデルのカラムにテキスト型の配列としてPartsを持たせる実装をした。但し、データが配列として登録されずに、文字列として登録されるため、gsub!やsplitを使って、配列に変えてからeachする必要があり、4日間も実装にかかってしまった。

# Why
Partモデルがあると、特にPartモデルを作成する機能がないアプリであるため、Partモデルをどう登録し、「その他」の楽器をどう登録するか、難しい問題があった。また、GigモデルとPartモデルを結び付けるのも複雑になってしまうため、GigモデルにPartsカラムを持たせる設計に変更した。